### PR TITLE
fix when user unselects image

### DIFF
--- a/croppie/fields.py
+++ b/croppie/fields.py
@@ -24,7 +24,7 @@ class CroppieField(forms.MultiValueField):
             fields=fields, widget=widget, *args, **kwargs)
 
     def compress(self, data_list):
-        if data_list:
+        if data_list and data_list[0]:
             data_image = data_list[0]
             ratio = data_list[1:]
             ratio = [int(i) for i in ratio]


### PR DESCRIPTION
Field is not required. User choose file, then clicks "choose file" again and then cancel. 

Received data are something like: [None, '254', '123', '356', '225']. Results in AttributeError: 'NoneType' object has no attribute 'read'.